### PR TITLE
Canonicalize lib names in deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,7 @@
            cambium/cambium.logback.core {:mvn/version "0.4.3"}
            org.clojure/clojure          {:mvn/version "1.10.1"}
            prismatic/schema             {:mvn/version "1.1.12"}
-           tupelo                       {:mvn/version "0.9.200"}
+           tupelo/tupelo                {:mvn/version "0.9.200"}
            }
 
  :aliases {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0-612"}}


### PR DESCRIPTION
Unqualified lib names are being deprecated in deps.edn and will warn